### PR TITLE
Update Convert-PemToPfx.ps1

### DIFF
--- a/PSPKI/Client/Convert-PemToPfx.ps1
+++ b/PSPKI/Client/Convert-PemToPfx.ps1
@@ -6,14 +6,29 @@
 [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true, Position = 0)]
-        [string]$InputPath,
-        [string]$KeyPath,
-        [string]$OutputPath,
-        [Security.Cryptography.X509Certificates.X509KeySpecFlags]$KeySpec = "AT_KEYEXCHANGE",
-        [Security.SecureString]$Password,
-        [string]$ProviderName = "Microsoft Enhanced RSA and AES Cryptographic Provider",
-        [Security.Cryptography.X509Certificates.StoreLocation]$StoreLocation = "CurrentUser",
-        [switch]$Install
+        [string]
+        $InputPath,
+        [Parameter()]
+        [string]
+        $KeyPath,
+        [Parameter()]
+        [string]
+        $OutputPath,
+        [Parameter()]
+        [Security.Cryptography.X509Certificates.X509KeySpecFlags]
+        $KeySpec = "AT_KEYEXCHANGE",
+        [Parameter()]
+        [Security.SecureString]
+        $Password,
+        [Parameter()]
+        [string]
+        $ProviderName = "Microsoft Enhanced RSA and AES Cryptographic Provider",
+        [Parameter()]
+        [Security.Cryptography.X509Certificates.StoreLocation]
+        $StoreLocation = "CurrentUser",
+        [Parameter()]
+        [switch]
+        $Install
     )
     if ($PSBoundParameters.Verbose) {$VerbosePreference = "continue"}
     if ($PSBoundParameters.Debug) {


### PR DESCRIPTION
Fixed reference to nonexistent `$_Cert` variable.
Fixed reference to nonexistent `$PSIsCore variable` Updated param section to match MS syntax guidelines This should now work in PS Core